### PR TITLE
Fix for nullable detection.

### DIFF
--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -331,7 +331,7 @@ class Macros {
 	}
 
 	static function isNullable( t : PropType ) {
-		switch( t.d ) {
+		switch( toFieldType(t) ) {
 		case PInt, PFloat, PBool:
 			return false;
 		default:


### PR DESCRIPTION
Without this, I get errors on static platforms due to hxbit not realizing that my abstracts are really basic types:

```
/home/ben/Dev/hxbit/hxbit/Macros.hx:388: characters 28-32 : On static platforms, null can't be used as basic type haxepunk.utils.Color
/home/ben/Dev/hxbit/hxbit/Macros.hx:483: characters 46-50 : On static platforms, null can't be used as basic type haxepunk.utils.Color
```