### PR TITLE
Fixed hash function on javascript target

### DIFF
--- a/hxbit/Serializer.hx
+++ b/hxbit/Serializer.hx
@@ -50,8 +50,10 @@ class Serializer {
 	static inline function hash(name:String) {
 		var v = 1;
 		for( i in 0...name.length )
-			v = v * 223 + StringTools.fastCodeAt(name,i);
+			v = Std.int(v * 223 + StringTools.fastCodeAt(name,i));
+
 		v = 1 + ((v & 0x3FFFFFFF) % 65423);
+
 		return v;
 	}
 


### PR DESCRIPTION
On javascript, the hash function was not correct. You're expecting the value to wrap around when overflowing, on JS it was treated as a float instead.