### PR TITLE
Fix explicit error message instead of null access

### DIFF
--- a/hxbit/Serializer.hx
+++ b/hxbit/Serializer.hx
@@ -730,8 +730,9 @@ class Serializer {
 		} else {
 			if( CLIDS[clidx] != 0 ) {
 				var realIdx = getCLID();
+				var c1 = c;
 				c = cast CL_BYID[realIdx];
-				if( c == null ) throw "Missing class #"+realIdx+" subclass of "+Type.getClassName(c)+"#"+clidx;
+				if( c == null ) throw "Missing class #"+realIdx+" subclass of "+Type.getClassName(c1)+"#"+clidx;
 				clidx = (c:Dynamic).__clid;
 			}
 		}


### PR DESCRIPTION
This fixes the `Null access .__name__` (Type.getClassName) during the error message from e7392b9