### PR TITLE
Allow overriding NetworkSerializable.setVisibilityDirty

### DIFF
--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -2006,7 +2006,7 @@ class Macros {
 					__host = old;
 				}
 				#if hxbit_visibility
-				public inline function setVisibilityDirty( group : hxbit.VisibilityGroup ) {
+				public function setVisibilityDirty( group : hxbit.VisibilityGroup ) {
 					__dirtyVisibilityGroups |= 1 << group.getIndex();
 					if( __next == null && __host != null ) @:privateAccess __host.mark(this);
 				}


### PR DESCRIPTION
This removes the inline on NetworkSerializable.setVisibilityDirty, allowing classes to override it.  

As far as I can tell the inline was not avoiding any allocations, and is sparsely called from gameplay code, so it does not yield an excessive amount of new function calls